### PR TITLE
fixed default value for "start on boot" value

### DIFF
--- a/app/src/main/java/com/SecUpwN/AIMSICD/receiver/BootCompletedReceiver.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/receiver/BootCompletedReceiver.java
@@ -16,7 +16,7 @@ public class BootCompletedReceiver extends BroadcastReceiver {
         SharedPreferences prefs = context.getSharedPreferences(
                 AimsicdService.SHARED_PREFERENCES_BASENAME, 0);
         final String AUTO_START = context.getString(R.string.pref_autostart_key);
-        boolean mAutoStart = prefs.getBoolean(AUTO_START, true);
+        boolean mAutoStart = prefs.getBoolean(AUTO_START, false);
         if (mAutoStart) {
             Log.i("AIMSICD", "System booted starting service.");
             context.startService(new Intent(context, AimsicdService.class));

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <!-- WARNING: Do not change default values in this file, without also updating the code where
+         the preference is used -->
     <PreferenceCategory
         android:key="pref_key_system_settings"
         android:title="@string/pref_system_title">
@@ -84,4 +85,4 @@
             android:title="@string/pref_ui_ocid_upload_title"/>
     </PreferenceCategory>
 
-</PreferenceScreen>
+used</PreferenceScreen>


### PR DESCRIPTION
As per comment in https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/issues/246