### PR TITLE
quit() method found to be not needed, as the issue lied in onDestroy()

### DIFF
--- a/app/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -348,7 +348,7 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
             Intent i = new Intent(this, DebugLogs.class);
             startActivity(i);
         } else if (selectedItem.getId() == 304) {
-            quit();
+            finish();
         }
 
         mDrawerList.setItemChecked(position, true);
@@ -639,23 +639,4 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
         }
     }
 
-    /**
-     * Method to entirely quit the app and stop services
-     * Fixes issue: #246
-     */
-    private void quit(){
-        /**
-         * Upon selection of Quit, all activities on top of the main will be closed
-         *
-         * Taken from StackOverflow:
-         * http://stackoverflow.com/questions/14001963/finish-all-activities-at-a-time
-         */
-        //Create an intent towards the main activity
-        Intent intent = new Intent(getApplicationContext(), AIMSICD.class);
-        //Set flag to close all activities above main upon start
-        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        //Tell main to exit
-        intent.putExtra("EXIT", true);
-        startActivity(intent);
-    }
 }


### PR DESCRIPTION
In onDestroy() of AIMSICD.java, when getting the boolean for the persistent service preference by using getBoolean(), the default value is now specified as "false".  Earlier, the value was set to "true" and was the reason that the app was not quitting as it should have been doing.  I have now discovered that this alone has resolved the issue, and not my initial commit.  My initial commit, consisting of finishing the app after launching the main activity via an intent with the flag FLAG_ACTIVITY_CLEAR_TOP set, did not actually make a difference it seems.  And so, after testing the removal of the current quit() method I have created in AIMSICD.java, where I have included the launching of this intent with said flag, I find that it has made no difference.  As mentioned in #246, it was recommended to look into the settings.xml file, but I think what was meant to be said was to look at preferences.xml.  When looking into the preferences, the pref_persistservice_service key has a default value of "false".  This is as it should be.  As said before, in the onDestroy() method in AIMSICD.java, when getting a preference, we must specify a value to use in the event the preference is not found.  This vlaue should be the same as the default value we want for the preference, and now it is.  I hope this clarifies the issue.