### PR TITLE
Fixed Issue #91 

### DIFF
--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -320,7 +320,7 @@ public class AIMSICDDbAdapter {
     /**
      * Checks to see if Cell already exists in OpenCellID database
      */
-    boolean openCellExists(int cellID) {
+    public boolean openCellExists(int cellID) {
         Cursor cursor = mDb.rawQuery("SELECT * FROM " + OPENCELLID_TABLE + " WHERE CellID = " +
                 cellID, null);
 


### PR DESCRIPTION
The lack of notification and tickerText in the event of cell ID not existing in OCID database has been resolved.  I have made use of, and have also made public, the method `openCellExists()` in AIMSICDDbAdapter.java. I call this method in `timerRunnable` right after the LAC is checked.  If the Cell ID does not exist, the newly created booloean mCellIdNotInOpenDb is set to true and `setNotification()` is called.  Unfortunately, another issue has been realized as we now know that in the instance of having multiple notifications, they are not displayed properly.  @He3556 and I have been discussing some possible solutions, nothing in detail yet, but this should be able to get fixed without too much of a headache.    