### PR TITLE
Fixed Issue #246 - CellTracker.java not stop()ing correctly

### DIFF
--- a/app/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -58,6 +58,7 @@ import com.SecUpwN.AIMSICD.fragments.AtCommandFragment;
 import com.SecUpwN.AIMSICD.fragments.DetailsContainerFragment;
 import com.SecUpwN.AIMSICD.service.AimsicdService;
 import com.SecUpwN.AIMSICD.service.CellTracker;
+import com.SecUpwN.AIMSICD.service.SignalStrengthTracker;
 import com.SecUpwN.AIMSICD.utils.AsyncResponse;
 import com.SecUpwN.AIMSICD.utils.Cell;
 import com.SecUpwN.AIMSICD.utils.GeoLocation;
@@ -99,11 +100,6 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        //Finish main activity if Quit was selected from NavDrawer
-        if (getIntent().getBooleanExtra("EXIT", false)) {
-            finish();
-        }
 
         getWindow().requestFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
 
@@ -213,8 +209,7 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
         final String PERSIST_SERVICE = mContext.getString(R.string.pref_persistservice_key);
         boolean persistService = prefs.getBoolean(PERSIST_SERVICE, false);
         if (!persistService) {
-            Intent intent = new Intent(mContext, AimsicdService.class);
-            stopService(intent);
+            stopService(new Intent(mContext, AimsicdService.class));
         }
     }
 

--- a/app/src/main/java/com/SecUpwN/AIMSICD/service/CellTracker.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/service/CellTracker.java
@@ -162,10 +162,20 @@ public class CellTracker implements SharedPreferences.OnSharedPreferenceChangeLi
     }
 
     public void stop() {
+        if(isMonitoringCell()) {
+            setCellMonitoring(false);
+        }
+        if(isTrackingCell()){
+            setCellTracking(false);
+        }
+        if(isTrackingFemtocell()){
+            stopTrackingFemto();
+        }
         cancelNotification();
         tm.listen(mCellSignalListener, PhoneStateListener.LISTEN_NONE);
         prefs.unregisterOnSharedPreferenceChangeListener(this);
         context.unregisterReceiver(mMessageReceiver);
+
     }
 
     /**


### PR DESCRIPTION
I have made a small change to `onDestroy()` in `AIMSICD.java` and I also have implemented a stop to tracking and monitoring, if they were enabled, in the `stop()` method of `CellTracker.java`.  This should be the end to #246 .