### PR TITLE
OCID: fix SU request spam

### DIFF
--- a/app/src/main/java/com/SecUpwN/AIMSICD/service/CellTracker.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/service/CellTracker.java
@@ -1077,7 +1077,7 @@ public class CellTracker implements SharedPreferences.OnSharedPreferenceChangeLi
                         // Check if CellID (CID) is in DBe_import (OpenCell) database (issue #91)
                         // See news in: issue #290  and compare to AIMSICDDbAdapter.java
                         // if ok then remove/change these comments.
-                        if ( Boolean.valueOf( Helpers.getProp("aimsicd.ocid_downloaded") ) ) {
+                        if ( Boolean.valueOf( Helpers.getSystemProp(CellTracker.this.context, "aimsicd.ocid_downloaded", "false") ) ) {
                             if (!dbHelper.openCellExists(mMonitorCell.getCID())) {
                                 Log.i(TAG, "ALERT: New CID -NOT- found in DBe_import: " + mMonitorCell.getCID());
 

--- a/app/src/main/java/com/SecUpwN/AIMSICD/utils/Helpers.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/utils/Helpers.java
@@ -464,10 +464,6 @@ import java.util.List;
         return Arrays.asList(Arrays.copyOf(display, newLength));
     }
 
-    public static String getProp(String prop) {
-        return CMDProcessor.runSuCommand("getprop " + prop).getStdout();
-    }
-
     public static String getSystemProp(Context context, String prop, String def) {
         String result = null;
         try {


### PR DESCRIPTION
This is NOT tested, not really, because I don't know much about the issues here.

Are you using a property because the two components are isolated from seeing each others' class data (like, one/both is a background service)?  Can we use the reflection trick to read the property, as I changed it to?  Even if we go command line, do we need root?  Hopefully I'm not missing something obvious here.