### PR TITLE
Switched CoverityScan analysis to branch development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,4 @@ addons:
 # Scan results: http://scan.coverity.com/projects/3346
     build_command_prepend: "./gradlew clean"
     build_command: "./gradlew build"
-    branch_pattern: master
+    branch_pattern: development


### PR DESCRIPTION
* Changed CoverityScan analysis to branch `development` in `.travis.yml` to use the current code.