### PR TITLE
Truncate GPS and make static reference to CSV path

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.SecUpwN.AIMSICD"
           android:versionCode="29"
-          android:versionName="0.1.29-alpha-b02">
+          android:versionName="0.1.29-alpha-b03">
 
     <!-- If we ever wanna make this a system app, we can add the following 2 lines above:
           coreApp="true"

--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -881,10 +881,14 @@ public class AIMSICDDbAdapter {
      *          "updateOpenCellID" to "populateDBe_import"
      */
     public boolean updateOpenCellID() {
-        File file = new File(RequestTask.getOCDBDownloadFilePath(mContext));
+        String filename = RequestTask.getOCDBDownloadFilePath(mContext);
+        Log.i(TAG, mTAG + ":updateOpenCellID: reading file: " + filename );
+
+        File file = new File(filename);
         try {
             if (file.exists()) {
                 CSVReader csvReader = new CSVReader(new FileReader(file));
+
                 OCIDCSV ocidCSV = new OCIDCSV();
                 String next[];
                 //FIXME Erase after refactoring.
@@ -1500,7 +1504,8 @@ public class AIMSICDDbAdapter {
                     "Lng VARCHAR, " +
                     "Signal INTEGER, " +
                     "Connection VARCHAR, " +
-                    "Timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP);";
+                    "Timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
+                    "UTC_Timestamp TIMESTAMP NOT NULL);";
             database.execSQL(LOC_DATABASE_CREATE);
         }
 

--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -22,6 +22,7 @@ import com.SecUpwN.AIMSICD.constants.Examples;
 import com.SecUpwN.AIMSICD.constants.Examples.EVENT_LOG_DATA;
 import com.SecUpwN.AIMSICD.utils.CMDProcessor;
 import com.SecUpwN.AIMSICD.utils.Cell;
+import com.SecUpwN.AIMSICD.utils.RequestTask;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -879,10 +880,7 @@ public class AIMSICDDbAdapter {
      *          "updateOpenCellID" to "populateDBe_import"
      */
     public boolean updateOpenCellID() {
-        String fileName = (mContext.getExternalFilesDir(null) + File.separator) + "OpenCellID/opencellid.csv";
-
-        Log.i(TAG, mTAG + ":updateOpenCellID: reading file: " + fileName );
-        File file = new File(fileName);
+        File file = new File(RequestTask.getOCDBDownloadFilePath(mContext));
         try {
             if (file.exists()) {
                 CSVReader csvReader = new CSVReader(new FileReader(file));

--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -1504,8 +1504,7 @@ public class AIMSICDDbAdapter {
                     "Lng VARCHAR, " +
                     "Signal INTEGER, " +
                     "Connection VARCHAR, " +
-                    "Timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
-                    "UTC_Timestamp TIMESTAMP NOT NULL);";
+                    "Timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP);";
             database.execSQL(LOC_DATABASE_CREATE);
         }
 

--- a/app/src/main/java/com/SecUpwN/AIMSICD/utils/OCIDCSV.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/utils/OCIDCSV.java
@@ -1,0 +1,88 @@
+package com.SecUpwN.AIMSICD.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Marvin Arnold on 9/06/15.
+ */
+public class OCIDCSV  extends ArrayList<OCIDCSV.OCIDCSVLine> {
+
+    public OCIDCSV() {
+        super();
+    }
+
+    public void add(String[] newLine) {
+        add(new OCIDCSVLine(newLine));
+    }
+
+
+    public class OCIDCSVLine {
+        private final String[] ocidCell;
+
+        public OCIDCSVLine(String[] ocidCell) {
+            this.ocidCell = ocidCell;
+        }
+
+        public double getGPSLat() {
+            return truncateDouble(this.ocidCell[0], 5);
+        }
+
+        public double getGPSLon() {
+            return truncateDouble(this.ocidCell[1], 5);
+        }
+
+        public int getMCC() {
+            return Integer.parseInt(this.ocidCell[2]);
+        }
+
+        public int getMNC() {
+            return Integer.parseInt(this.ocidCell[3]);
+        }
+
+        public int getLAC() {
+            return Integer.parseInt(this.ocidCell[4]);
+        }
+
+        public int getCID() {
+            return Integer.parseInt(this.ocidCell[5]);
+        }
+
+        /**
+         * Average signal in dBm
+         * @return
+         */
+        public int getAvgSig() {
+            return Integer.parseInt(this.ocidCell[6]);
+        }
+
+        /**
+         * Average range in m
+         * @return
+         */
+        public int getAvgRange() {
+            return Integer.parseInt(this.ocidCell[7]);
+        }
+
+        public int getSamples() {
+            return Integer.parseInt(this.ocidCell[8]);
+        }
+
+        public int isGPSExact() {
+            return Integer.parseInt(this.ocidCell[9]);
+        }
+
+        public String getRAT() {
+            return String.valueOf(this.ocidCell[10]);
+        }
+
+        public double truncateDouble(String d, int numDecimal) {
+            return  truncateDouble(Double.parseDouble(d), numDecimal);
+        }
+
+        public double truncateDouble(double d, int numDecimal) {
+            String s = String.format("%." + Integer.toString(numDecimal) +"f", d);
+            return Double.parseDouble(s);
+        }
+    }
+}

--- a/app/src/main/java/com/SecUpwN/AIMSICD/utils/OCIDCSV.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/utils/OCIDCSV.java
@@ -16,7 +16,6 @@ public class OCIDCSV  extends ArrayList<OCIDCSV.OCIDCSVLine> {
         add(new OCIDCSVLine(newLine));
     }
 
-
     public class OCIDCSVLine {
         private final String[] ocidCell;
 
@@ -49,7 +48,7 @@ public class OCIDCSV  extends ArrayList<OCIDCSV.OCIDCSVLine> {
         }
 
         /**
-         * Average signal in dBm
+         * Average signal in [dBm]
          * @return
          */
         public int getAvgSig() {
@@ -57,7 +56,7 @@ public class OCIDCSV  extends ArrayList<OCIDCSV.OCIDCSVLine> {
         }
 
         /**
-         * Average range in m
+         * Average range in [m]
          * @return
          */
         public int getAvgRange() {

--- a/app/src/main/java/com/SecUpwN/AIMSICD/utils/RequestTask.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/utils/RequestTask.java
@@ -192,10 +192,11 @@ public class RequestTask extends BaseAsyncTask<String, Integer, String> {
                 try {
                     int total;
                     int progress = 0;
-
-                    File dir = new File(getOCDBDownloadDirectoryPath(mAppContext));
+                    String dirName = getOCDBDownloadDirectoryPath(mAppContext);
+                    File dir = new File(dirName);
                     if (!dir.exists()) { dir.mkdirs(); } // need a try{} catch{}
                     File file = new File(dir, OCDB_File_Name);
+                    Log.i(TAG, mTAG + ": DBE_DOWNLOAD_REQUEST write to: " + dirName + OCDB_File_Name);
 
                     URL url = new URL(commandString[0]);
                     HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();

--- a/app/src/main/java/com/SecUpwN/AIMSICD/utils/RequestTask.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/utils/RequestTask.java
@@ -193,9 +193,9 @@ public class RequestTask extends BaseAsyncTask<String, Integer, String> {
                     int total;
                     int progress = 0;
 
-                    File dir = new File((mAppContext.getExternalFilesDir(null) + File.separator) + "OpenCellID/");
+                    File dir = new File(getOCDBDownloadDirectoryPath(mAppContext));
                     if (!dir.exists()) { dir.mkdirs(); } // need a try{} catch{}
-                    File file = new File(dir, "opencellid.csv");
+                    File file = new File(dir, OCDB_File_Name);
 
                     URL url = new URL(commandString[0]);
                     HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
@@ -418,5 +418,20 @@ public class RequestTask extends BaseAsyncTask<String, Integer, String> {
         if (lActivity != null && lActivity instanceof MapViewerOsmDroid) {
             ((MapViewerOsmDroid) lActivity).setRefreshActionButtonState(pFlag);
         }
+    }
+
+    public static final String OCDB_File_Name = "opencellid.csv";
+
+    /**
+     * The folder path to OCDB download.
+     * @param context
+     * @return
+     */
+    public static String getOCDBDownloadDirectoryPath(Context context) {
+        return (context.getExternalFilesDir(null) + File.separator) + "OpenCellID/";
+    }
+
+    public static String getOCDBDownloadFilePath(Context context) {
+        return getOCDBDownloadDirectoryPath(context) + OCDB_File_Name;
     }
 }


### PR DESCRIPTION
Follow up commit to bug #434 to make CSV path consistent across files.
Truncate OCID GPS to five digits per #325.