### PR TITLE
Read OCID cells from nogapps location too + map fix

### DIFF
--- a/app/src/main/java/com/SecUpwN/AIMSICD/activities/MapViewerOsmDroid.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/activities/MapViewerOsmDroid.java
@@ -44,6 +44,11 @@ import com.SecUpwN.AIMSICD.utils.Helpers;
 import com.SecUpwN.AIMSICD.utils.RequestTask;
 import com.SecUpwN.AIMSICD.utils.TinyDB;
 
+import org.osmdroid.api.IProjection;
+import org.osmdroid.events.DelayedMapListener;
+import org.osmdroid.events.MapListener;
+import org.osmdroid.events.ScrollEvent;
+import org.osmdroid.events.ZoomEvent;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
@@ -99,6 +104,7 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
     private boolean mBound;
 
     private GeoPoint loc = null;
+    private AsyncTask<Void,Void,GeoPoint> mLoadTask = null;
 
     private MyLocationNewOverlay mMyLocationOverlay;
     private CompassOverlay mCompassOverlay;
@@ -109,14 +115,27 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
     private PhoneStateListener mPhoneStateListener = new PhoneStateListener() {
         @Override
         public void onServiceStateChanged(ServiceState serviceState) {
-            loadEntries();
+            loadEntries(true);
         }
 
         @Override
         public void onCellInfoChanged(List<CellInfo> cellInfo) {
-            loadEntries();
+            loadEntries(true);
         }
     };
+
+    private MapListener mMapListener = new DelayedMapListener(new MapListener() {
+        public boolean onScroll(ScrollEvent event) {
+            loadEntries(false);
+            return true;
+        }
+
+        public boolean onZoom(ZoomEvent event) {
+            // TODO: no need to update when zooming in
+            loadEntries(false);
+            return true;
+        }
+    }, 250);
 
     /**
      * Called when the activity is first created.
@@ -139,6 +158,8 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
         TelephonyManager tm = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
         tm.listen(mPhoneStateListener, PhoneStateListener.LISTEN_CELL_LOCATION |
                 PhoneStateListener.LISTEN_DATA_CONNECTION_STATE);
+
+        mMap.setMapListener(mMapListener);
     }
 
     @Override
@@ -160,7 +181,7 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
         }
 
         loadPreferences();
-        loadEntries();
+        loadEntries(true);
 
         if (mCompassOverlay != null) {
             mCompassOverlay.enableCompass();
@@ -204,7 +225,7 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
     private final BroadcastReceiver mMessageReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            loadEntries();
+            loadEntries(true);
             if(BuildConfig.DEBUG && mCellTowerGridMarkerClusterer != null && mCellTowerGridMarkerClusterer.getItems() != null) {
                 Log.v(TAG, "mMessageReceiver CellTowerMarkers.invalidate() markers.size():" + mCellTowerGridMarkerClusterer.getItems().size());
             }
@@ -381,11 +402,14 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
      *  Description:    Loads Signal Strength Database details to plot on the map,
      *                  only entries which have a location (lon, lat) are used.
      *
-     *
      */
-    private void loadEntries() {
+    private void loadEntries(final boolean updateLocation) {
+        // it doesn't make sense to have multiple tasks running
+        if (mLoadTask != null && mLoadTask.getStatus() != AsyncTask.Status.FINISHED) {
+          mLoadTask.cancel(true);
+        }
 
-        new AsyncTask<Void,Void,GeoPoint>() {
+        mLoadTask = new AsyncTask<Void,Void,GeoPoint>() {
             @Override
             protected GeoPoint doInBackground(Void... voids) {
                 final int SIGNAL_SIZE_RATIO = 15;  // A scale factor to draw BTS Signal circles
@@ -406,6 +430,7 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
                 }
                 if (c != null && c.moveToFirst()) {
                     do {
+                        if (isCancelled()) return null;
                         // The indexing here is that of the Cursor and not the DB table itself
                         final int cellID = c.getInt(0);  // CID
                         final int lac = c.getInt(1);     // LAC
@@ -444,8 +469,6 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
                             ovm.setIcon(getResources().getDrawable(R.drawable.ic_map_pin_blue));
 
                             items.add(ovm);
-
-
                         }
 
                     } while (c.moveToNext());
@@ -474,9 +497,13 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
                 mDbHelper.close();
 
                 // plot neighbouring cells
-                while (mAimsicdService == null) try { Thread.sleep(100); } catch (Exception e) {}
+                while (mAimsicdService == null) try {
+                  if (isCancelled()) return null;
+                  Thread.sleep(100);
+                } catch (Exception e) {}
                 List<Cell> nc = mAimsicdService.getCellTracker().updateNeighbouringCells();
                 for (Cell cell : nc) {
+                    if (isCancelled()) return null;
                     try {
                         loc = new GeoPoint(cell.getLat(), cell.getLon());
                         CellTowerMarker ovm = new CellTowerMarker(mContext,mMap,
@@ -504,6 +531,59 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
                 return ret;
             }
 
+            // TODO: Consider changing this function name to:  <something else>
+            private void loadOpenCellIDMarkers() {
+                // Check if OpenCellID data exists and if so load this now
+                LinkedList<CellTowerMarker> items = new LinkedList<>();
+
+                // DBe_import tower pins.
+                Drawable cellTowerMarkerIcon = getResources().getDrawable(R.drawable.ic_map_pin_green);
+
+                mDbHelper.open();
+                IProjection p = mMap.getProjection();
+                Cursor c = mDbHelper.getOpenCellIDDataByRegion(
+                    p.getSouthWest().getLatitude(), p.getSouthWest().getLongitude(),
+                    p.getNorthEast().getLatitude(), p.getNorthEast().getLongitude()
+                 );
+                if (c.moveToFirst()) {
+                    if (isCancelled()) return;
+                    do {
+                        // The indexing here is that of the Cursor and not the DB table itself:
+                        // CellID,Lac,Mcc,Mnc,Lat,Lng,AvgSigStr,Samples
+                        final int cellID = c.getInt(0);
+                        final int lac = c.getInt(1);
+                        final int mcc = c.getInt(2);
+                        final int mnc = c.getInt(3);
+                        final double dlat = Double.parseDouble(c.getString(4));
+                        final double dlng = Double.parseDouble(c.getString(5));
+                        final GeoPoint location = new GeoPoint(dlat, dlng);
+                        //
+                        final int samples = c.getInt(7);
+
+                        // Add map marker for CellID
+                        CellTowerMarker ovm = new CellTowerMarker(mContext, mMap,
+                                "Cell ID: " + cellID,
+                                "", location,
+                                new MarkerData(
+                                        "" + cellID,
+                                        "" + location.getLatitude(),
+                                        "" + location.getLongitude(),
+                                        "" + lac,
+                                        "" + mcc,
+                                        "" + mnc,
+                                        "" + samples,
+                                        false));
+
+                        ovm.setIcon(cellTowerMarkerIcon);
+                        items.add(ovm);
+                    } while (c.moveToNext());
+                }
+                c.close();
+                mDbHelper.close();
+
+                mCellTowerGridMarkerClusterer.addAll(items);
+            }
+
             /**
              *  TODO:  We need a manual way to add our own location in case:
              *          a) GPS is jammed or not working
@@ -514,25 +594,27 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
              */
             @Override
             protected void onPostExecute(GeoPoint defaultLoc) {
-                if (loc != null && (loc.getLatitude() != 0.0 && loc.getLongitude() != 0.0)) {
-                    mMap.getController().setZoom(16);
-                    mMap.getController().animateTo(new GeoPoint(loc.getLatitude(), loc.getLongitude()));
-                } else {
-                    if (mBound) {
-                        // Try and find last known location and zoom there
-                        GeoLocation lastLoc = mAimsicdService.lastKnownLocation();
-                        if (lastLoc != null) {
-                            loc = new GeoPoint(lastLoc.getLatitudeInDegrees(),
-                                    lastLoc.getLongitudeInDegrees());
+                if (updateLocation) {
+                    if (loc != null && (loc.getLatitude() != 0.0 && loc.getLongitude() != 0.0)) {
+                        mMap.getController().setZoom(16);
+                        mMap.getController().animateTo(new GeoPoint(loc.getLatitude(), loc.getLongitude()));
+                    } else {
+                        if (mBound) {
+                            // Try and find last known location and zoom there
+                            GeoLocation lastLoc = mAimsicdService.lastKnownLocation();
+                            if (lastLoc != null) {
+                                loc = new GeoPoint(lastLoc.getLatitudeInDegrees(),
+                                        lastLoc.getLongitudeInDegrees());
 
-                            mMap.getController().setZoom(16);
-                            mMap.getController().animateTo(new GeoPoint(loc.getLatitude(), loc.getLongitude()));
-                        } else {
-                            //Use MCC to move camera to an approximate location near Countries Capital
-                            loc = defaultLoc;
+                                mMap.getController().setZoom(16);
+                                mMap.getController().animateTo(new GeoPoint(loc.getLatitude(), loc.getLongitude()));
+                            } else {
+                                //Use MCC to move camera to an approximate location near Countries Capital
+                                loc = defaultLoc;
 
-                            mMap.getController().setZoom(12);
-                            mMap.getController().animateTo(new GeoPoint(loc.getLatitude(), loc.getLongitude()));
+                                mMap.getController().setZoom(12);
+                                mMap.getController().animateTo(new GeoPoint(loc.getLatitude(), loc.getLongitude()));
+                            }
                         }
                     }
                 }
@@ -544,55 +626,8 @@ public class MapViewerOsmDroid extends BaseActivity implements OnSharedPreferenc
                     mCellTowerGridMarkerClusterer.invalidate();
                 }
             }
-        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-    }
-
-    // TODO: Consider changing this function name to:  <something else>
-    private void loadOpenCellIDMarkers() {
-        // Check if OpenCellID data exists and if so load this now
-        LinkedList<CellTowerMarker> items = new LinkedList<>();
-
-        // DBe_import tower pins.
-        Drawable cellTowerMarkerIcon = getResources().getDrawable(R.drawable.ic_map_pin_green);
-
-        mDbHelper.open();
-        Cursor c = mDbHelper.getOpenCellIDData();
-        if (c.moveToFirst()) {
-            do {
-                // The indexing here is that of the Cursor and not the DB table itself:
-                // CellID,Lac,Mcc,Mnc,Lat,Lng,AvgSigStr,Samples
-                final int cellID = c.getInt(0);
-                final int lac = c.getInt(1);
-                final int mcc = c.getInt(2);
-                final int mnc = c.getInt(3);
-                final double dlat = Double.parseDouble(c.getString(4));
-                final double dlng = Double.parseDouble(c.getString(5));
-                final GeoPoint location = new GeoPoint(dlat, dlng);
-                //
-                final int samples = c.getInt(7);
-
-                // Add map marker for CellID
-                CellTowerMarker ovm = new CellTowerMarker(mContext, mMap,
-                        "Cell ID: " + cellID,
-                        "", location,
-                        new MarkerData(
-                                "" + cellID,
-                                "" + location.getLatitude(),
-                                "" + location.getLongitude(),
-                                "" + lac,
-                                "" + mcc,
-                                "" + mnc,
-                                "" + samples,
-                                false));
-
-                ovm.setIcon(cellTowerMarkerIcon);
-                items.add(ovm);
-            } while (c.moveToNext());
-        }
-        c.close();
-        mDbHelper.close();
-
-        mCellTowerGridMarkerClusterer.addAll(items);
+        };
+        mLoadTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {

--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -592,6 +592,16 @@ public class AIMSICDDbAdapter {
         );
     }
 
+    public Cursor getOpenCellIDDataByRegion(Double lat1, Double lng1, Double lat2, Double lng2) {
+        return mDb.query( OPENCELLID_VIEW,
+                new String[]{"CellID", "Lac", "Mcc", "Mnc", "Lat", "Lng", "AvgSigStr", "Samples"},
+                // avg_range, rej_cause, Type
+                "? <= Lng AND Lng <= ? AND ? <= Lat AND Lat <= ?",
+                new String[]{lng1.toString(), lng2.toString(), lat1.toString(), lat2.toString()},
+                null, null, null
+        );
+    }
+
     /**
      * Returns Default MCC Locations (defaultlocation) database contents
      */

--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -112,6 +112,7 @@ public class AIMSICDDbAdapter {
     private final String LOCATION_TABLE     = "locationinfo";    // TABLE_DBI_MEASURE:DBi_measure (volatile)
     private final String CELL_TABLE         = "cellinfo";        // TABLE_DBI_BTS:DBi_bts (physical)
     private final String OPENCELLID_TABLE   = "opencellid";      // TABLE_DBE_IMPORT:DBe_import
+    private final String OPENCELLID_VIEW    = "opencellid_view"; // OCID local + lacells (volatile)
     private final String TABLE_DEFAULT_MCC  = "defaultlocation"; // TABLE_DEFAULT_MCC:defaultlocation
     private final String SILENT_SMS_TABLE   = "silentsms";       // TABLE_SILENT_SMS:silentsms
 
@@ -131,6 +132,10 @@ public class AIMSICDDbAdapter {
     // private final String TABLE_SECTORTYPE  = "SectorType";       // BTS tower sector configuration (Many CID, same BTS)
     // private final String TABLE_SILENTSMS   = "silentsms";        // Silent SMS details
     // private final String TABLE_CMEASURES   = "CounterMeasures";  // Counter Measures thresholds and description
+
+    private final String LACELLS_DB_NAME  = "/sdcard/.nogapps/lacells.db";
+    private final String LACELLS_LOCAL_DB = "lacells";
+    private final String LACELLS_TABLE    = "cells";
 
     private final String[] mTables;
     private final DbHelper mDbHelper;
@@ -580,7 +585,7 @@ public class AIMSICDDbAdapter {
      *
      */
     public Cursor getOpenCellIDData() {
-        return mDb.query( OPENCELLID_TABLE,
+        return mDb.query( OPENCELLID_VIEW,
                 new String[]{"CellID", "Lac", "Mcc", "Mnc", "Lat", "Lng", "AvgSigStr", "Samples"},
                 // avg_range, rej_cause, Type
                 null, null, null, null, null
@@ -632,10 +637,10 @@ public class AIMSICDDbAdapter {
 
     /**
      *  Description:    This checks if a cell with a given CID already exists
-     *                  in the "opencellid" (DBe_import) database.
+     *                  in the "opencellid" (DBe_import) or optional lacells database.
      */
     public boolean openCellExists(int cellID) {
-        Cursor cursor = mDb.rawQuery("SELECT * FROM " + OPENCELLID_TABLE +
+        Cursor cursor = mDb.rawQuery("SELECT * FROM " + OPENCELLID_VIEW +
                         " WHERE CellID = " + cellID, null);
         boolean exists = cursor.getCount() > 0;
         //Log.v(TAG, mTAG + ": Does CID: " + cellID + " exist in DBe_import? " + exists);
@@ -1369,13 +1374,16 @@ public class AIMSICDDbAdapter {
      *
      *  Description:    This class creates all the tables and DB structure in aimsicd.db when
      *                  AIMSICD is first started or updated when DB version changed.
+     *                  Also creates a view that merges lacells.db with local OCID.
      *
      *  Issues:
      *              [ ] Migrate table creation to use an SQL file import instead.
      *                  This will simplify the maintenance of the tables and the
      *                  create create process.
      *
-     *              [ ]
+     *              [ ] Avoid duplicates when cell is in both local and lacells tables
+     *
+     *              [ ] DRY checkDBe() and DbHelper.onConfigure() filter
      *
      *  ChangeLog:
      *
@@ -1384,6 +1392,30 @@ public class AIMSICDDbAdapter {
 
         DbHelper(Context context) {
             super(context, DB_NAME, null, DATABASE_VERSION);
+        }
+
+        // Create a view merging local OCID and lacells.db database rows.
+        @Override
+        public void onOpen(SQLiteDatabase db) {
+            String CreateView = "CREATE TEMP VIEW " +
+                    OPENCELLID_VIEW + " AS" +
+                    " SELECT CellID, Lac, Mcc, Mnc, Lat, Lng, AvgSigStr, Samples" +
+                    " FROM " + OPENCELLID_TABLE;
+
+            File lacells = new File(LACELLS_DB_NAME);
+            if (lacells.isFile() && lacells.canRead()) {
+                db.execSQL("ATTACH DATABASE \"" + LACELLS_DB_NAME + "\" AS " + LACELLS_LOCAL_DB);
+                // signal strength is (usually) not present in lacells
+                CreateView += " UNION ALL" +
+                    " SELECT cid AS CellID, lac AS Lac, mcc AS Mcc, mnc AS Mnc," +
+                        " latitude AS Lat, longitude AS Lng, NULL AS AvgSigStr, samples AS Samples" +
+                    " FROM " + LACELLS_LOCAL_DB + "." + LACELLS_TABLE +
+                    " WHERE Samples >= 1 AND Lac >= 1 AND Lac <= 65535" +
+                    " AND CellID >= 1 AND CellID <= 268435455 ";
+                    //" GROUP BY CellID, Lac, Mcc, Mnc"; // much too slow
+            }
+
+            db.execSQL(CreateView);
         }
 
         // Create aimsicd.db table structure 

--- a/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/app/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -1404,6 +1404,12 @@ public class AIMSICDDbAdapter {
 
             File lacells = new File(LACELLS_DB_NAME);
             if (lacells.isFile() && lacells.canRead()) {
+                // Make sure it has a location index. Separate connection to avoid locking issues.
+                // TODO this can take a while the first time, provide UI feedback
+                SQLiteDatabase ladb = SQLiteDatabase.openDatabase(LACELLS_DB_NAME, null, 0);
+                ladb.execSQL("CREATE INDEX IF NOT EXISTS _idxspatial ON " + LACELLS_TABLE + " (latitude, longitude);");
+                ladb.close();
+                // Attach to existing connection for cross-database join
                 db.execSQL("ATTACH DATABASE \"" + LACELLS_DB_NAME + "\" AS " + LACELLS_LOCAL_DB);
                 // signal strength is (usually) not present in lacells
                 CreateView += " UNION ALL" +
@@ -1610,6 +1616,7 @@ public class AIMSICDDbAdapter {
                     //"Timestamp TIMESTAMP NOT NULL DEFAULT current_timestamp, " +
                     ");";
             database.execSQL(OPENCELLID_DATABASE_CREATE);
+            database.execSQL("CREATE INDEX OpenCellID_spatial ON " + OPENCELLID_TABLE + " (latitude, longitude);");
         }
 
         /**


### PR DESCRIPTION
Users of UnifiedNLP's [Local-GSM-Backend](https://github.com/n76/Local-GSM-Backend) already have an OpenCellID database on their phone. This PR brings in support for that, plus a fix for the map view that allows it to work with large OCID databases.

When the AIMSICD database is opened, a view is created used for querying OCID. Usually this view is the same as the local database table, but when the other OpenCellID database is found, this view becomes a union of the local and other database.

I found the map view to be choking on the amount of datapoints in my OpenCellID database. This PR also limits the cells loaded in the map view to the area shown, which solves the issue for higher zoom-levels. #466