### PR TITLE
Versioning using GIT abbreviated commit ID

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ def getManifestVersionCode() {
      def matcher = pattern.matcher(manifestText)
      matcher.find()
      def version = Integer.parseInt(matcher.group(1))
-     println sprintf("Returning version %d", version)
+     println sprintf("Returning version code %d", version)
      return version
 }
 
@@ -31,7 +31,9 @@ def getManifestVersionName() {
      def matcher = pattern.matcher(manifestText)
      matcher.find()
      def zname = matcher.group(1)
-     println sprintf("Returning version %s", zname)
+     def git = org.ajoberstar.grgit.Grgit.open(file('..'))
+     zname += "-" + git.head().abbreviatedId
+     println sprintf("Returning version name %s", zname)
      return zname
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.SecUpwN.AIMSICD"
           android:versionCode="36"
-          android:versionName="0.1.36-alpha-b00">
+          android:versionName="0.1.36-alpha">
 
     <!-- If we ever wanna make this a system app, we can add the following 2 lines above:
           coreApp="true"

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.+'
+        classpath 'org.ajoberstar:grgit:1.1.0'
     }
 }
 


### PR DESCRIPTION
Using short form of current commit id and appending it to current, manifest defined, `versionName`

+ Edited reports to say if returning version code or name

```
> gradle assembleRelease -S
Starting a new Gradle Daemon for this build (subsequent builds will be faster).
Importing with getManifestVersionCode()
Returning version code 36
Importing with getManifestVersionName()
Returning version name 0.1.36-alpha-0747dc5
```

This closes #147