### PR TITLE
Removed unnecessary access

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,20 +27,14 @@
     <uses-permission android:name="android.permission.READ_LOGS"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.RECEIVE_SMS"/>
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-
-    <!-- NEW -->
-    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED"/>
-    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES"/>
-    <uses-permission android:name="android.permission.NFC"/>
-    <uses-permission android:name="android.permission.READ_CONTACTS"/>
-    <uses-permission android:name="android.permission.READ_SMS"/>
     <uses-permission android:name="android.permission.RECEIVE_MMS"/>
     <uses-permission android:name="android.permission.RECEIVE_WAP_PUSH"/>
-    <uses-permission android:name="android.permission.USE_SIP"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES"/>
+    <uses-permission android:name="android.permission.READ_SMS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
@@ -64,10 +58,6 @@
     <uses-permission android:name="android.permission.WRITE_APN_SETTINGS"/>
     <!--uses-permission android:name="android.permission.WRITE_GSERVICES"/ -->
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"/>
-
-    <!-- possibly deprecated -->
-    <uses-permission android:name="android.permission.RECEIVE_EMERGENCY_BROADCAST"/>
-    <uses-permission android:name="android.permission.READ_NETWORK_USAGE_HISTORY"/>
 
     <!-- These are OEM / Samsung Permissions -->
     <uses-permission android:name="android.phone.receiveDetailedCallState"/>


### PR DESCRIPTION
First attempt to clean up our system permissions to solve #636 and related but already closed #427. Next step before merging this branch should be to check if these changes are correct and to structure our `AndroidManifest.xml` according to the [Android Best Practices](https://github.com/futurice/android-best-practices). We also need to keep the upcoming [Permissions at Run Time](https://developer.android.com/training/permissions/requesting.html) in mind so that our app will work on future Android releases. Thank you, folks!

>Beginning in Android 6.0 (API level 23), users grant permissions to apps while the app is running, not when they install the app. This approach streamlines the app install process, since the user does not need to grant permissions when they install or update the app.

@smarek and @DJaeger, please add your improvements to this branch! Further reading if needed:

* **[AndroidPermissionsUsage](https://github.com/RomainPiel/AndroidPermissionsUsage)**
* [PermissionHelper](https://github.com/k0shk0sh/PermissionHelper)
* [Android RuntimePermissions Sample](https://github.com/googlesamples/android-RuntimePermissions)
* [Working with AndroidManifest.xml ](https://developer.xamarin.com/guides/android/advanced_topics/working_with_androidmanifest.xml/)