### PR TITLE
Removed OEM / Samsung Permissions to fix #690

### DIFF
--- a/AIMSICD/src/main/AndroidManifest.xml
+++ b/AIMSICD/src/main/AndroidManifest.xml
@@ -1,52 +1,27 @@
+    <!-- Privacy Enthusiasts: Please read our Permissions Statement linked below!  -->
+    <!-- https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/wiki/Permissions -->
+
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.SecUpwN.AIMSICD">
 
-    <!-- If we ever wanna make this a system app, we can add the following 2 lines above:
-          coreApp="true"
-          android:sharedUserId="android.uid.system"> -->
-
-    <!-- PERMISSIONS ARE SORTED BY AOS PERMISSION AND 3rd PARTY ACCESS. KEEP THIS! -->
-    <!-- https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/wiki/Permissions -->
-
-    <!-- Normal Android third-party permissions -->
-    <uses-permission android:name="android.permission.ACCESS_SUPERUSER"/>
+    <!-- Normal Android third-party permissions, sorted for better viewing -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_UPDATES"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_SUPERUSER"/>
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <!-- SPECIAL PERMISSIONS TO BE ADDED AFTER THIS LINE. /> -->
-    <!-- To list all available (used) Android permissions on a device, use:
-         # `pm list permissions -g`  -->
-
-    <!-- These are OEM / Samsung Permissions -->
-    <uses-permission android:name="android.phone.receiveDetailedCallState"/>
-    <uses-permission android:name="com.android.permission.HANDOVER_STATUS"/>
-    <uses-permission android:name="com.sec.android.app.controlpanel.permission.PRIVATE"/>
-    <uses-permission android:name="com.sec.android.app.factorymode.permission.KEYSTRING"/>
-    <uses-permission android:name="com.sec.android.app.cm.permission.PERMISSION_MANAGEMENT"/>
-    <uses-permission android:name="com.sec.android.app.phoneutil.permission.KEYSTRING"/>
-    <uses-permission android:name="com.sec.android.app.servicemodeapp.permission.KEYSTRING"/>
-    <uses-permission android:name="com.sec.android.phone.permission.DATA_ROAMING_SETTINGS_ENHANCED"/>
-    <uses-permission android:name="com.sec.android.phone.permission.READ_CALL_SETTINGS"/>
-    <uses-permission android:name="com.sec.android.phone.permission.WRITE_CALL_SETTINGS"/>
-    <!-- uses-permission android:name="com.sec.factory.permission.ALLOWFTCLIENTCPOBIND"/>
-    <uses-permission android:name="com.sec.factory.permission.BT_ID_WRITE"/ -->
-    <uses-permission android:name="com.sec.factory.permission.KEYSTRING"/>
-    <uses-permission android:name="com.sec.modem.settings.permission.KEYSTRING"/>
-    <!-- uses-permission android:name="diagandroid.app.receiveDetailedApplicationState"/>
-    <uses-permission android:name="diagandroid.data.receivePDPContextState"/>
-    <uses-permission android:name="diagandroid.phone.receiveDetailedCallState"/ -->
 
     <!-- May be needed (in the future) to access SIM related functions -->
     <uses-permission android:name="org.simalliance.openmobileapi.SMARTCARD"/>

--- a/AIMSICD/src/main/AndroidManifest.xml
+++ b/AIMSICD/src/main/AndroidManifest.xml
@@ -1,10 +1,13 @@
-    <!-- Privacy Enthusiasts: Please read our Permissions Statement linked below!  -->
-    <!-- https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/wiki/Permissions -->
-
 <?xml version="1.0" encoding="utf-8"?>
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.SecUpwN.AIMSICD">
+
+    <!--
+        Privacy Enthusiasts: Please read our Permissions Statement linked below!
+        https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/wiki/Permissions
+    -->
 
     <!-- Normal Android third-party permissions, sorted for better viewing -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
@@ -25,7 +28,7 @@
 
     <!-- May be needed (in the future) to access SIM related functions -->
     <uses-permission android:name="org.simalliance.openmobileapi.SMARTCARD"/>
-   
+
     <application
             tools:replace="allowBackup"
             android:allowBackup="false"

--- a/AIMSICD/src/main/AndroidManifest.xml
+++ b/AIMSICD/src/main/AndroidManifest.xml
@@ -26,8 +26,10 @@
 
     <!-- SPECIAL PERMISSIONS TO BE ADDED AFTER THIS LINE. /> -->
 
-    <!-- May be needed (in the future) to access SIM related functions -->
-    <uses-permission android:name="org.simalliance.openmobileapi.SMARTCARD"/>
+    <!--
+        May be needed (in the future) to access SIM related functions
+        <uses-permission android:name="org.simalliance.openmobileapi.SMARTCARD"/>
+    -->
 
     <application
             tools:replace="allowBackup"


### PR DESCRIPTION
This pull request cleans the Samsung specific permissions in our `AndroidManifest.xml` which prevented our app to be successfully installed on other hardware like HTC phones and adds small enhancements.

---

@larsgrefer, can you find out what needs to be changed to fix the following error?

```
FAILURE: Build failed with an exception.

* What went wrong:

A problem occurred configuring project ':AIMSICD'.

> Cannot read packageName from /home/travis/build/SecUpwN/Android-IMSI-Catcher-Detector/AIMSICD/src/main/AndroidManifest.xml
```