### PR TITLE
Disable proguard obfuscation

### DIFF
--- a/AIMSICD/proguard-rules.txt
+++ b/AIMSICD/proguard-rules.txt
@@ -1,10 +1,10 @@
+-dontobfuscate
 -verbose
 -optimizationpasses 5
 -dontpreverify
 -dump class_files.txt
 -printseeds seeds.txt
 -printusage unused.txt
--printmapping mapping.txt
 
 -keepattributes *Annotation*
 -keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
We don't have anything to hide so obfuscation only makes stacktraces harder to read

@SecUpwN please review and merge