### PR TITLE
Have only one `android.intent.action.MAIN`

### DIFF
--- a/AIMSICD/src/main/AndroidManifest.xml
+++ b/AIMSICD/src/main/AndroidManifest.xml
@@ -92,7 +92,6 @@
             android:parentActivityName=".AIMSICD">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
-                <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.INFO"/>
             </intent-filter>
         </activity>


### PR DESCRIPTION
Since otherwise this will baffle some apps trying to launch the app, you get the About screen but the back arrow only closes the app, case in point:
* F-Droid, app screen, Launch
* package installer, after install you can Launch the app