### PR TITLE
First cleanup of Javadoc comments

### DIFF
--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -97,8 +97,6 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        moveData();
-
         mNavConf = new DrawerMenuActivityConfiguration.Builder(this).build();
 
         setContentView(mNavConf.getMainLayout());
@@ -670,5 +668,4 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
         super.onStart();
         ((AppAIMSICD) getApplication()).attach(this);
     }
-
 }

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -16,7 +16,6 @@ import android.content.SharedPreferences.Editor;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.IBinder;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
@@ -50,6 +49,7 @@ import com.SecUpwN.AIMSICD.utils.Icon;
 import com.SecUpwN.AIMSICD.utils.LocationServices;
 import com.SecUpwN.AIMSICD.utils.RequestTask;
 import com.SecUpwN.AIMSICD.utils.StackOverflowXmlParser;
+
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
@@ -57,7 +57,6 @@ import com.squareup.okhttp.Response;
 
 import org.xmlpull.v1.XmlPullParserException;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -671,34 +671,4 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
         ((AppAIMSICD) getApplication()).attach(this);
     }
 
-    /**
-     * Moves file from user directory to app-dedicated directory.
-     * 
-     * TODO: Remove move in 2016. All people should have more than enough time to update their
-     * AIMSICD this method will be obsolete.
-     * 
-     */
-    private void moveData() {
-        // /storage/emulated/0/Android/data/com.SecUpwN.AIMSICD/
-        File destinedPath = new File(getExternalFilesDir(null) + File.separator);
-        // /storage/emulated/0/AIMSICD
-        File currentPath = new File(Environment.getExternalStorageDirectory().toString() + "/AIMSICD");
-
-        //checks if  /storage/emulated/0/AIMSICD exists
-        if (currentPath.exists()) {
-            // and if it's a directory, don't touch files
-            if (currentPath.isDirectory()) {
-                //list all files (and folders) in /storage/emulated/0/AIMSICD
-                File[] content = currentPath.listFiles();
-                for (int i = 0; i < content.length; i++) {
-                    File from = new File(content[i].toString());
-                    //move file to new directory
-                    from.renameTo(new File(destinedPath.toString() + content[i].getName().toString()));
-                }
-            }
-            //remove current directory so it won't try to move it again
-            currentPath.delete();
-        }
-    }
-
 }

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -64,13 +64,6 @@ import java.util.List;
 import io.freefair.android.injection.annotation.Inject;
 import io.freefair.android.util.logging.Logger;
 
-/**
- * Description:     TODO: Please add some comments about this class
- * <p>
- * Dependencies:    TODO: Write a few words about where the content of this is used.
- * <p>
- * Issues:
- */
 public class AIMSICD extends BaseActivity implements AsyncResponse {
 
     @Inject
@@ -232,14 +225,14 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
     }
 
     /**
-     * Description:     Swaps fragments in the main content view
+     * Swaps fragments in the main content view
      */
     void selectItem(int position) {
         NavDrawerItem selectedItem = mNavConf.getNavItems().get(position);
         String title = selectedItem.getLabel();
 
         /**
-         * This is a work-around for Issue 42601
+         * This is a work-around for Android Issue 42601
          * https://code.google.com/p/android/issues/detail?id=42601
          *
          * The method getChildFragmentManager() does not clear up
@@ -304,7 +297,7 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
         } else if (selectedItem.getId() == DrawerMenu.ID.SETTINGS.RESET_DB) {
             // WARNING! This deletes the entire database, thus any subsequent DB access will FC app.
             //          Therefore we need to either restart app or run AIMSICDDbAdapter, to rebuild DB.
-            //          See: #581 and Helpers.java
+            //          See: https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/issues/581 and Helpers.java
             Helpers.askAndDeleteDb(this);
 
 
@@ -647,22 +640,14 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
     }
 
     /**
-     * Description:     Cell Information Tracking - Enable/Disable
-     * <p>
-     * TODO: Clarify usage and what functions we would like this to provide. - Are we toggling GPS
-     * location tracking? - Are we logging measurement data into DBi? - Are we locking phone to
-     * 2/3/4G operation?
+     * Cell Information Tracking - Enable/Disable
      */
     private void trackCell() {
         mAimsicdService.setCellTracking(mAimsicdService.isTrackingCell());
     }
 
     /**
-     * Description:     Cell Information Monitoring - Enable/Disable
-     * <p>
-     * TODO: Clarify usage and what functions we would like this to provide. - Are we temporarily
-     * disabling AIMSICD monitoring? (IF yes, why not just Quit?) - Are we ignoring Detection
-     * alarms? - Are we logging something?
+     * Cell Information Monitoring - Enable/Disable
      */
     private void monitorCell() {
         mAimsicdService.setCellMonitoring(!mAimsicdService.isMonitoringCell());
@@ -688,10 +673,10 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
 
     /**
      * Moves file from user directory to app-dedicated directory.
-     * <p>
+     * 
      * TODO: Remove move in 2016. All people should have more than enough time to update their
      * AIMSICD this method will be obsolete.
-     * <p>
+     * 
      */
     private void moveData() {
         // /storage/emulated/0/Android/data/com.SecUpwN.AIMSICD/

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/activities/OpenCellIdActivity.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/activities/OpenCellIdActivity.java
@@ -26,8 +26,8 @@ import io.freefair.android.injection.annotation.XmlLayout;
 import io.freefair.android.util.logging.Logger;
 
 /**
- *  Description:    Popup toast messages asking if user wants to download new API key
- *                  to access OpenCellId services and data.
+ *  Popup toast messages asking if user wants to download
+ *  new API key to access OpenCellId services and data.
  */
 @XmlLayout(R.layout.activity_open_cell_id)
 public class OpenCellIdActivity extends BaseActivity {
@@ -128,8 +128,6 @@ public class OpenCellIdActivity extends BaseActivity {
          * Description:     Get an API key for Open Cell ID. Do not call this from the UI/Main thread.
          *                  For the various server responses, pleas refer to the OpenCellID API wiki:
          *                  http://wiki.opencellid.org/wiki/API#Error_codes
-         *                  TODO: And the github issue #303:
-         *                  https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/issues/303
          *
          *      OCID status codes http://wiki.opencellid.org/wiki/API#Error_codes
          *

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/activities/OpenCellIdActivity.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/activities/OpenCellIdActivity.java
@@ -125,19 +125,19 @@ public class OpenCellIdActivity extends BaseActivity {
 
         /**
          *
-         * Description:     Get an API key for Open Cell ID. Do not call this from the UI/Main thread.
-         *                  For the various server responses, pleas refer to the OpenCellID API wiki:
-         *                  http://wiki.opencellid.org/wiki/API#Error_codes
+         * Get an API key for Open Cell ID. Do not call this from the UI/Main thread.
+         * For the various server responses, pleas refer to the OpenCellID API wiki:
+         * See: http://wiki.opencellid.org/wiki/API#Error_codes
          *
-         *      OCID status codes http://wiki.opencellid.org/wiki/API#Error_codes
+         * OCID status codes http://wiki.opencellid.org/wiki/API#Error_codes
          *
-         *      1 	200 	Cell not found
-         *      2 	401 	Invalid API key
-         *      3 	400 	Invalid input data
-         *      4 	403     Your API key must be white listed in order to run this operation
-         *      5 	500 	Internal server error
-         *      6 	503 	Too many requests. Try later again
-         *      7 	429     Daily limit 1000 requests exceeded for your API key.
+         * 1 	200 	Cell not found
+         * 2 	401 	Invalid API key
+         * 3 	400 	Invalid input data
+         * 4 	403     Your API key must be white listed in order to run this operation
+         * 5 	500 	Internal server error
+         * 6 	503 	Too many requests. Try later again
+         * 7 	429     Daily limit 1000 requests exceeded for your API key.
          *
          * @return null or newly generated key
          */

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/activities/OpenCellIdActivity.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/activities/OpenCellIdActivity.java
@@ -28,9 +28,6 @@ import io.freefair.android.util.logging.Logger;
 /**
  *  Description:    Popup toast messages asking if user wants to download new API key
  *                  to access OpenCellId services and data.
- *
- *  TODO:
- *              [ ] Add toast for every server response code/message
  */
 @XmlLayout(R.layout.activity_open_cell_id)
 public class OpenCellIdActivity extends BaseActivity {
@@ -134,9 +131,8 @@ public class OpenCellIdActivity extends BaseActivity {
          *                  TODO: And the github issue #303:
          *                  https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/issues/303
          *
-         *  TODO:   [ ] Add handlers for other HTTP request and OCID Server error codes:
-         *
          *      OCID status codes http://wiki.opencellid.org/wiki/API#Error_codes
+         *
          *      1 	200 	Cell not found
          *      2 	401 	Invalid API key
          *      3 	400 	Invalid input data

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/CellCardInflater.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/CellCardInflater.java
@@ -14,18 +14,9 @@ import com.SecUpwN.AIMSICD.R;
 
 
 /**
- * Brief:   TODO: Please explain its use.
- *
- * Description:
- *
- *      This class handle all the AMISICD DataBase ... TODO: Add info here !
- *
- *
- *
- *  Issues:     TODO:  !! === I'm not sure this is the right place... == !! --E:V:A
- *  Notes:
- *
+ * This class handles the AMISICD DataBase
  */
+ 
 public class CellCardInflater implements IAdapterViewInflater<CardItemData> {
 
     @Override

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/DbeImportCardInflater.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/DbeImportCardInflater.java
@@ -19,8 +19,6 @@ import com.SecUpwN.AIMSICD.R;
  *                  DbViewerFragment.java: BuildTable()
  *                  DbeImportItemData.java
  *                  dbe_import_items.xml
- *
- *  Issues:
  */
 public class DbeImportCardInflater implements IAdapterViewInflater<DbeImportItemData> {
 

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/DbeImportCardInflater.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/DbeImportCardInflater.java
@@ -13,13 +13,9 @@ import android.widget.TextView;
 import com.SecUpwN.AIMSICD.R;
 
 /**
- *  Description:     Contains the data and definitions of all the items of the XML layout
- *
- *  Dependencies:
- *                  DbViewerFragment.java: BuildTable()
- *                  DbeImportItemData.java
- *                  dbe_import_items.xml
+ * Contains the data and definitions of all the items of the XML layout
  */
+ 
 public class DbeImportCardInflater implements IAdapterViewInflater<DbeImportItemData> {
 
     @Override

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/EventLogCardInflater.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/EventLogCardInflater.java
@@ -13,19 +13,12 @@ import android.widget.TextView;
 import com.SecUpwN.AIMSICD.R;
 
 /**
- *  Brief:          TODO: Please explain its use.
+ *  This class handles the EventLog DB table.
  *
- *  Description:
+ *  Template:     OpenCellIdCardInflater.java
  *
- *      This class handle the EventLog DB table ... TODO: Add info here !
- *
- *  Template:       OpenCellIdCardInflater.java
- *
- *  Dependencies:   EventLogItemData.java
- *                  eventlog_items.xml
- *
- *  Issues:
- *  Notes:
+ *  Dependencies: EventLogItemData.java
+ *                eventlog_items.xml
  *
  */
 public class EventLogCardInflater implements IAdapterViewInflater<EventLogItemData> {

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/EventLogCardInflater.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/EventLogCardInflater.java
@@ -14,13 +14,8 @@ import com.SecUpwN.AIMSICD.R;
 
 /**
  *  This class handles the EventLog DB table.
- *
- *  Template:     OpenCellIdCardInflater.java
- *
- *  Dependencies: EventLogItemData.java
- *                eventlog_items.xml
- *
  */
+ 
 public class EventLogCardInflater implements IAdapterViewInflater<EventLogItemData> {
 
     @Override

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/MeasuredCellStrengthCardInflater.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/MeasuredCellStrengthCardInflater.java
@@ -16,7 +16,6 @@ import com.SecUpwN.AIMSICD.R;
  * Inflater class used in DB viewer (for Measured cell strength measurements)
  *
  * Template:    SilentSmsCardInflater.java
- * TODO:        Fix variable names!!
  *
  * @author Tor Henning Ueland
  */

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/constants/DBTableColumnIds.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/constants/DBTableColumnIds.java
@@ -1,11 +1,8 @@
 package com.SecUpwN.AIMSICD.constants;
 /**
- * Description:     These are some static constants that represent the SQLite DB
- *                  table names. These should normally NOT be used, as hardcoded strings
- *                  make everything much more transparent...
- *
- * Note:            Try keep the same order as in the aimsicd.sql tables
- *
+ * These are some static constants that represent the SQLite DB table names.
+ * These should normally NOT be used, as hardcoded strings make everything
+ * much more transparent. Try keep the same order as in the aimsicd.sql tables.
  */
 public class DBTableColumnIds {
     //defaultlocation

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/constants/Examples.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/constants/Examples.java
@@ -6,16 +6,13 @@
 package com.SecUpwN.AIMSICD.constants;
 
 /**
- * Description:     This class add Constants for examples as used to pre-populate
- *                  various tables used in the Database Viewer (DBV).
- *
- * Dependencies:    DbViewerFragment.java
+ *  This class add Constants for examples as used to pre-populate
+ *  various tables used in the Database Viewer (DBV).
  */
 public class Examples {
 
     /**
-     * Description:     Constants of examples for EventLogItemData
-     * Dependencies:    EventLogItemData.java
+     *  Constants of examples for EventLogItemData
      */
     public static class EVENT_LOG_DATA {
         public static final String LAC = "12345";
@@ -28,8 +25,7 @@ public class Examples {
     }
 
     /**
-     * Description:     Constants of examples for SilentSmsCardData
-     * Dependencies:    SilentSmsCardData.java
+     * Constants of examples for SilentSmsCardData
      */
     public static class SILENT_SMS_CARD_DATA {
         public static final String ADDRESS = "ADREZZ";

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/CellTowerGridMarkerClusterer.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/CellTowerGridMarkerClusterer.java
@@ -12,8 +12,8 @@ import org.osmdroid.bonuspack.clustering.RadiusMarkerClusterer;
 import java.util.List;
 
 /**
- * Description:     Overlay class for OSMDroid map to display multiple BTS pins
- *                  as one numbered point, clustering multiple pins.
+ * Overlay class for OSMDroid map to display multiple BTS pins
+ * as one numbered point, clustering multiple pins.
  */
 public class CellTowerGridMarkerClusterer extends RadiusMarkerClusterer {
     protected Context mContext;

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/CellTowerMarker.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/CellTowerMarker.java
@@ -51,10 +51,6 @@ public class CellTowerMarker extends Marker {
      * more available items as explained in the related issue here:
      * https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/issues/234
      *
-     * Dependency:
-     *              MarkerData.java
-     *              marker_info_window.xml
-     *
      */
     public View getInfoContents(MarkerData data) {
 

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/CellTowerMarker.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/CellTowerMarker.java
@@ -79,7 +79,6 @@ public class CellTowerMarker extends Marker {
                 tv.setText(String.valueOf(data.lat));
                 tv = (TextView) v.findViewById(R.id.lng);       // LON
                 tv.setText(String.valueOf(data.lng));
-                // TODO: add PSC and RAT
                 //tv = (TextView) v.findViewById(R.id.psc);     // PSC
                 //tv.setText(data.getPSC());
                 //tv = (TextView) v.findViewById(R.id.rat);     // RAT

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/MarkerData.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/map/MarkerData.java
@@ -6,13 +6,8 @@
 package com.SecUpwN.AIMSICD.map;
 
 /**
- * Description:     Class to hold data for displaying in BTS pin popup dialog
  *
- * Issues:
- *                  [ ] clarify which GPS coordinates are used. Exact of from device?
- *                  [ ] adding more details, similar as for the DB Viewer UI:
- *                      see: https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/issues/234
- *
+ * Class to hold data for displaying in BTS pin popup dialog
  *
  */
 public class MarkerData {

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/rilexecutor/RilExecutor.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/rilexecutor/RilExecutor.java
@@ -110,9 +110,9 @@ public class RilExecutor {
 
 
     /**
-     * Check the status of the Rill Executor
+     * Check the status of the RIL Executor
      *
-     * @return DetectResult providing access status of the Ril Executor
+     * @return DetectResult providing access status of the RIL Executor
      */
     public DetectResult getRilExecutorStatus() {
         return mRilExecutorDetectResult;
@@ -157,9 +157,9 @@ public class RilExecutor {
 
     /**
      * Executes and receives the Ciphering Information request using
-     * the Rill Executor
+     * the RIL Executor
      *
-     * @return String list response from Rill Executor
+     * @return String list response from RIL Executor
      */
     public List<String> getCipheringInfo() {
         return executeServiceModeCommand(
@@ -171,9 +171,9 @@ public class RilExecutor {
 
     /**
      * Executes and receives the Neighbouring Cell request using
-     * the Rill Executor
+     * the RIL Executor
      *
-     * @return String list response from Rill Executor
+     * @return String list response from RIL Executor
      */
     public List<String> getNeighbours() {
         KeyStep getNeighboursKeySeq[] = new KeyStep[]{

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/rilexecutor/SamsungMulticlientRilExecutor.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/rilexecutor/SamsungMulticlientRilExecutor.java
@@ -33,9 +33,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- *      Description:
- */
 public class SamsungMulticlientRilExecutor implements OemRilExecutor {
 
     private final Logger log = AndroidLogger.forClass(SamsungMulticlientRilExecutor.class);

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/service/AimsicdService.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/service/AimsicdService.java
@@ -47,9 +47,8 @@ import io.freefair.android.injection.app.InjectionService;
 import io.freefair.android.util.logging.Logger;
 
 /**
- *  Description:    This starts the (background?) AIMSICD service to check for SMS and track
- *                  cells with or without GPS enabled.
- *                  TODO: better and more detailed explanation!
+ * This starts the (background?) AIMSICD service to check for SMS and track
+ * cells with or without GPS enabled.
  */
 public class AimsicdService extends InjectionService {
 

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/smsdetection/AdvancedUserActivity.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/smsdetection/AdvancedUserActivity.java
@@ -128,7 +128,7 @@ public class AdvancedUserActivity extends InjectionAppCompatActivity {
     }
 
     /**
-     Reload ListView with new database values
+     * Reload ListView with new database values
      */
     public void loadDbString(){
         ArrayList<AdvanceUserItems> newmsglist;

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/Cell.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/Cell.java
@@ -9,10 +9,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.os.SystemClock;
 
-
-/**
- * Description:    TODO:  What've got here...
- */
 public class Cell implements Parcelable {
 
     // Cell Specific Variables
@@ -391,12 +387,6 @@ public class Cell implements Parcelable {
         return this.rssi;
     }
 
-
-    /**
-     * TODO: What is this, and where is it supposed to be used ???
-     *
-     * @return
-     */
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/Device.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/Device.java
@@ -15,12 +15,6 @@ import android.telephony.gsm.GsmCellLocation;
 import io.freefair.android.util.logging.AndroidLogger;
 import io.freefair.android.util.logging.Logger;
 
-/**
- * Description:     TODO
- *
- * Issues:
- *              [ ] The use of wrong API for some calls in the cell tracker
- */
 public class Device {
 
     private final Logger log = AndroidLogger.forClass(Device.class);

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/DeviceApi17.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/DeviceApi17.java
@@ -28,11 +28,6 @@ import java.util.List;
 import io.freefair.android.util.logging.AndroidLogger;
 import io.freefair.android.util.logging.Logger;
 
-/**
- *  Description:    TODO
- *
- *  Created by toby on 10/10/14.
- */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 public class DeviceApi17 {
 

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/DeviceApi18.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/DeviceApi18.java
@@ -29,19 +29,11 @@ import io.freefair.android.util.logging.Logger;
 import java.util.List;
 
 /**
- *  Description:    This class is taking in consideration newly available network info items
- *                  that are only available in the AOS API 18 and above. In this case we're 
- *                  concerned with Wcdma Cell info...  CellInfoWcdma
- *  NOTES:
- *                See:  http://developer.android.com/reference/android/os/Build.VERSION_CODES.html
+ * This class is taking in consideration newly available network info items
+ * that are only available in the AOS API 18 and above. In this case we're 
+ * concerned with Wcdma Cell info (CellInfoWcdma)
  *
- *                JELLY_BEAN      16      Android 4.1
- *                JELLY_BEAN_MR1  17      Android 4.2
- *                JELLY_BEAN_MR2  18      Android 4.3
- *                KITKAT          19      Android 4.4
- *                KITKAT_WATCH    20      Android 4.4W
- *                LOLLIPOP        21      Android 5.xx
- *                LOLLIPOP_MR1    22      Android 5.yy
+ * See: http://developer.android.com/reference/android/os/Build.VERSION_CODES.html
  *
  */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/GeoLocation.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/GeoLocation.java
@@ -5,14 +5,13 @@
  */
 
 /**
- * Description:
- *              This util is used to calculate various points on a sphere from GPS coordinates
+ * This util is used to calculate various points on a sphere from GPS coordinates
  *
- *              Represents a point on the surface of a sphere. (The Earth is almost spherical.)
- *              To create an instance, call one of the static methods fromDegrees() or fromRadians().
+ * Represents a point on the surface of a sphere. (The Earth is almost spherical.)
+ * To create an instance, call one of the static methods fromDegrees() or fromRadians().
  *
- *              This code was originally published at:
- *              http://JanMatuschek.de/LatitudeLongitudeBoundingCoordinates#Java
+ * This code was originally published at:
+ * http://JanMatuschek.de/LatitudeLongitudeBoundingCoordinates#Java
  *
  * @author Jan Philip Matuschek
  * @version 22 September 2010
@@ -121,11 +120,9 @@ public class GeoLocation {
     }
 
     /**
-     * Description:
-     *
-     *      Computes the bounding coordinates of all points on the surface of a
-     *      sphere that have a great circle distance to the point represented by this
-     *      GeoLocation instance that is less or equal to the distance argument.
+     * Computes the bounding coordinates of all points on the surface of a
+     * sphere that have a great circle distance to the point represented by this
+     * GeoLocation instance that is less or equal to the distance argument.
      *
      *
      * @param distance the distance from the point represented by this
@@ -138,22 +135,22 @@ public class GeoLocation {
      *
      * @return an array of two GeoLocation objects such that:
      *
-     *      The latitude of any point within the specified distance is
-     *      greater or equal to the latitude of the first array element and
-     *      smaller or equal to the latitude of the second array element.
+     * The latitude of any point within the specified distance is
+     * greater or equal to the latitude of the first array element and
+     * smaller or equal to the latitude of the second array element.
      *
-     *      If the longitude of the first array element is smaller or
-     *      equal to the longitude of the second element, then the longitude
-     *      of any point within the specified distance is greater or equal to
-     *      the longitude of the first array element and smaller or equal to
-     *      the longitude of the second array element.
+     * If the longitude of the first array element is smaller or
+     * equal to the longitude of the second element, then the longitude
+     * of any point within the specified distance is greater or equal to
+     * the longitude of the first array element and smaller or equal to
+     * the longitude of the second array element.
      *
-     *      If the longitude of the first array element is greater than
-     *      the longitude of the second element (this is the case if the
-     *      180th meridian is within the distance), then the longitude of any
-     *      point within the specified distance is greater or equal to the
-     *      longitude of the first array element OR smaller
-     *      or equal to the longitude of the second array element.
+     * If the longitude of the first array element is greater than
+     * the longitude of the second element (this is the case if the
+     * 180th meridian is within the distance), then the longitude of any
+     * point within the specified distance is greater or equal to the
+     * longitude of the first array element OR smaller
+     * or equal to the longitude of the second array element.
      *
      */
     public GeoLocation[] boundingCoordinates(double distance, double radius) {

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/MiscUtils.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/MiscUtils.java
@@ -96,11 +96,11 @@ public class MiscUtils {
 
 
     /*
-     *  Description:    Converts logcat timstamp to SQL friendly timstamps
-     *                  We use this to determine if an sms has already been found
+     * Converts logcat timstamp to SQL friendly timstamps
+     * We use this to determine if an sms has already been found
      *
-     *      Converts a timstamp in this format:     06-17 22:06:05.988 D/dalvikvm(24747):
-     *      Returns a timestamp in this format:     20150617223311
+     * Converts a timstamp in this format:     06-17 22:06:05.988 D/dalvikvm(24747):
+     * Returns a timestamp in this format:     20150617223311
      */
     public static String logcatTimeStampParser(String line){
         String[] buffer = line.split(" ");

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/MiscUtils.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/MiscUtils.java
@@ -28,9 +28,6 @@ import java.util.Locale;
 import io.freefair.android.util.logging.AndroidLogger;
 import io.freefair.android.util.logging.Logger;
 
-/**
- * Description:     TODO
- */
 public class MiscUtils {
 
     private static final Logger log = AndroidLogger.forClass(MiscUtils.class);

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/StackOverflowXmlParser.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/StackOverflowXmlParser.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 
 /**
- *  Description:    TODO: please add this...
+ *  StackOverflowXmlParser populates a List of entries with data from the feed
  */
 public class StackOverflowXmlParser {
     // We don't use namespaces

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/SystemPropertiesReflection.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/SystemPropertiesReflection.java
@@ -28,20 +28,8 @@ import java.lang.reflect.Method;
 import dalvik.system.DexFile;
 
 /**
- *  Description:    Class using reflection to grant access to the private hidden
- *                  android.os.SystemProperties class
- *
- *  Dependency:     SystemProperties.java
- *
- *  Usage:          Helpers.java
- *
- *  Issues:
- *              [ ]  Can simplify the code according to below link
- *
- *  Notes:
- *
- *    https://github.com/android/platform_frameworks_base/blob/master/core/java/android/os/SystemProperties.java
- *    http://stackoverflow.com/a/28402378/1147688
+ * Class using reflection to grant access to the private hidden
+ * android.os.SystemProperties class
  */
 public class SystemPropertiesReflection {
 

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/TinyDB.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/TinyDB.java
@@ -23,17 +23,13 @@ import java.util.Map;
 
 
 /**
- *  Description:    This class simplifies calls to SharedPreferences in a line of code.
- *                  It can also do more like: saving a list of Strings or Integers and Saving images.
- *                  All in 1 line of code!
+ * This class simplifies calls to SharedPreferences in a line of code.
+ * It can also do more like: saving a list of Strings or Integers and Saving images.
  *
- *  Example usage:
+ * See: http://stackoverflow.com/questions/5734721/android-shared-preferences
+ *      https://github.com/kcochibili/TinyDB--Android-Shared-Preferences-Turbo/
  *
- *  See:
- *    http://stackoverflow.com/questions/5734721/android-shared-preferences
- *    https://github.com/kcochibili/TinyDB--Android-Shared-Preferences-Turbo/
- *
- *  Usage:
+ * Usage:
  *
  *  1)
  *      import com.SecUpwN.AIMSICD.utils.TinyDB;

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/atcmd/TtyPrivFile.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/atcmd/TtyPrivFile.java
@@ -7,17 +7,6 @@ package com.SecUpwN.AIMSICD.utils.atcmd;
 
 import java.io.IOException;
 
-
-/**
- *  Description:    ...
- *
- *  Issues:     [ ]
- *
- *              [ ]
- *
- *
- *  Notes:
- */
 public class TtyPrivFile extends TtyStream {
 
     protected Process mReadProc;

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/atcmd/TtyStream.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/utils/atcmd/TtyStream.java
@@ -19,17 +19,6 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-/**
- *  Description:    ...
- *
- *  Issues:     [ ]
- *
- *              [ ]
- *
- *
- *  Notes:
- */
-
 /*package*/
 class TtyStream extends AtCommandTerminal {
 

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/widget/ScaledTransitionHandler.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/widget/ScaledTransitionHandler.java
@@ -9,7 +9,7 @@ import com.kaichunlin.transition.internal.TransitionController;
  * The progress valued passed to @link {@link #onUpdateScaledProgress(TransitionController, View, float)} has taken the start and
  * end range into consideration. The method will only be called when the progress is within range, and the value passed has been
  * scaled to always be [0..1].
- * <p>
+ * 
  * Created by Kai-Chun Lin on 2015/9/16.
  */
 public abstract class ScaledTransitionHandler implements TransitionHandler {


### PR DESCRIPTION
This PR is the start of multiple PRs to clean up our codebase from the following sections to fix #672:

* Comments and whole conversations
* Issues (moved into GitHub Issues)
* TODO (moved into GitHub Issues)

~~I have kept the `Description` prefix where applicable, in some files a small description is better.~~
@larsgrefer, a list of still dirty files is in the OP of #672, maybe you can add fixes for those here?