### PR TITLE
Calculate versionNames from git-tags

### DIFF
--- a/AIMSICD/build.gradle
+++ b/AIMSICD/build.gradle
@@ -17,8 +17,6 @@ if (isTravis) {
     buildNumber = System.getenv("BUILDOZER_BUILDNUMBER")
 }
 
-version = '0.1.39.1-alpha'
-
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,16 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'io.freefair.gradle-plugins:android:2.0.0-beta1'
+        classpath 'io.freefair:gradle-plugins:2.0.0-beta1'
     }
 }
+
+apply plugin: 'io.freefair.git-version'
 
 allprojects {
     repositories {
         jcenter()
         maven { url "https://jitpack.io" }
     }
+    version = rootProject.version
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,15 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'io.freefair:gradle-plugins:2.0.0-beta1'
+        classpath 'io.freefair:gradle-plugins:2.0.0-beta3'
     }
 }
 
 apply plugin: 'io.freefair.git-version'
+
+gitVersion {
+    tagPrefix 'v'
+}
 
 allprojects {
     repositories {


### PR DESCRIPTION
This pull request is aiming to calculate the `versionName` from git-tags. Before we can merge this, @ijansch needs to tell us here if the Issue with undetected `git` ([stacktrace](https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/commit/f23e9fe80e2abff03d536bcf48e06a86796bbea1#commitcomment-15168328)) has been resolved in Buildozer. @larsgrefer, would you please add a few arguments here why calculating them is better?