### PR TITLE
Unchaining WIP-Release v0.1.40.1-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,7 @@ addons:
     branch_pattern: master
 
 before_deploy:
-  - cd AIMSICD/build/outputs/apk
-  - md5sum *-normal-release.apk > md5sum.txt
-  - sha1sum *-normal-release.apk > sha1sum.txt
-  - cd -
+  - cd AIMSICD/build/outputs/apk; md5sum *-normal-release.apk > md5sum.txt; sha1sum *-normal-release.apk > sha1sum.txt; cd -
 
 deploy:
   skip_cleanup: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG of 'AIMSICD'
 ------------------------
 
+#### [21.02.2016 - WIP-Release v0.1.40.1-alpha](https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/releases/tag/v0.1.40-alpha)
+
+* Fixed: Travis-CI does now attach the correctly signed APK again
+
+---
+
 #### [21.02.2016 - WIP-Release v0.1.40-alpha](https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/releases/tag/v0.1.40-alpha)
 
 * Removed: Purged unused imports and `ATCommandActivity`


### PR DESCRIPTION
Tiny bugfix release in order to make Travis-CI behave again like it should and attach the signed APK.