### PR TITLE
Don't truncate MNC integer after 2 chars in OCID download

### DIFF
--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -379,9 +379,9 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
 
             if (networkOperator != null) {
                 int mcc = Integer.parseInt(networkOperator.substring(0, 3));
-                cell.setMCC(Integer.parseInt(networkOperator.substring(0, 3)));
+                cell.setMCC(mcc);
                 int mnc = Integer.parseInt(networkOperator.substring(3));
-                cell.setMNC(Integer.parseInt(networkOperator.substring(3, 5)));
+                cell.setMNC(mnc);
                 log.debug("CELL:: mcc=" + mcc + " mnc=" + mnc);
             }
 


### PR DESCRIPTION
This was causing issues, obviously, where OCID would provide a HTTP 200 response of an empty dataset for devices with an MNC length greater than 2 chars

This is what was causing #790 for me. Of course the area I'm in has a cell that's _**not**_ in the OCID (verified via manual lookup) but I can confirm I now see ~400 cells imported into my phone and if I go for a stroll, I expect status to go to green.

First real Android PR you guise :tada: 