### PR TITLE
null-guard service before driving menu options

### DIFF
--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/AIMSICD.java
@@ -453,16 +453,53 @@ public class AIMSICD extends BaseActivity implements AsyncResponse {
         super.onPause();
     }
 
+    /**
+     * Invoked only once during app's lifetime. For successive calls see
+     * {@link #onPrepareOptionsMenu(Menu)}. Both used primarily to determine checkboxes for tracking
+     * and detection.
+     *
+     * Because the service may not available on app boot, we default to false until the service
+     * boots. Once that occurs, the checkboxes are driven by the service's status.
+     *
+     * @param menu
+     * @return
+     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.main_menu, menu);
 
         MenuItem toggleAttackDetectionMenuItem = menu.findItem(R.id.toggle_attack_detection);
-        toggleAttackDetectionMenuItem.setChecked(mAimsicdService.isMonitoringCell());
         MenuItem toggleCellTrackingMenuItem = menu.findItem(R.id.toggle_cell_tracking);
-        toggleCellTrackingMenuItem.setChecked(mAimsicdService.isTrackingCell());
+
+        // The service may not exist on first app boot. Choose sane defaults
+        if (mAimsicdService == null) {
+            toggleAttackDetectionMenuItem.setChecked(false);
+            toggleCellTrackingMenuItem.setChecked(false);
+        } else {
+            toggleAttackDetectionMenuItem.setChecked(mAimsicdService.isMonitoringCell());
+            toggleCellTrackingMenuItem.setChecked(mAimsicdService.isTrackingCell());
+        }
         return true;
+    }
+
+    /**
+     * Display latest cell tracking & attack detection truth when opening menu over & over
+     *
+     * @param menu
+     * @return
+     */
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        // Bail early if there's no service to get the facts from
+        if (mAimsicdService == null) {
+            return super.onPrepareOptionsMenu(menu);
+        }
+        MenuItem toggleAttackDetectionMenuItem = menu.findItem(R.id.toggle_attack_detection);
+        MenuItem toggleCellTrackingMenuItem = menu.findItem(R.id.toggle_cell_tracking);
+        toggleAttackDetectionMenuItem.setChecked(mAimsicdService.isMonitoringCell());
+        toggleCellTrackingMenuItem.setChecked(mAimsicdService.isTrackingCell());
+        return super.onPrepareOptionsMenu(menu);
     }
 
     @Override


### PR DESCRIPTION
#### Agreements

- [x] **I have reviewed and accepted the [guidelines for contributing](https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/blob/development/.github/CONTRIBUTING.md) to this project.**
- [x] **I have reviewed and closely followed the [Style Guide](https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/wiki/Style-Guide) for this Android app.**

---

#### Overview

This PR fixes the app crashing on boot on fresh installs & newly booted phones.

Pull request #798, solving #794, fails to account for fresh installs & newly booted phones where the service is not instantiated/running by the time the menu is created for the first time and a NPE occurs.

If the service is null, simply choose "false" since without a service there is no way tracking is happening.

Added `onPrepareOptionsMenu` implementation that will redraw the checkboxes depending on the latest truth every time the menu is open. *Not sure if this is unnecessary!*

---

#### Classification

- [x] Bugfix (non-breaking change which fixes an existing issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

#### References
>If your pull request is related to or solves any existing Issues, please link them here.

Resolves an oversight in #798 which fixed #794.
