### PR TITLE
Display RAT in map marker details populated by DBi_bts

### DIFF
--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/adapters/AIMSICDDbAdapter.java
@@ -263,12 +263,18 @@ public final class AIMSICDDbAdapter extends SQLiteOpenHelper {
 
 
     /**
-     * Returns Cell Information (DBi_bts) database contents
-     * this returns BTSs that we logged and is called from
-     * MapFragment.java to display cells on map
+     * <p>Returns Cell Information (DBi_bts) database contents this returns BTSs that we logged and is
+     * called from MapFragment.java to display cells on map</p>
+     *
+     * <p>Because RAT is stored in measurement table. JOIN the two table together for a complete
+     * picture.</p>
+     *
+     * <p>TODO: 2016-02-28 Consider if this is the best way to get the info. Database schema refactor?</p>
+     *
+     * @see #returnDBiBtsWithRAT()
      */
     public Cursor getCellData() {
-        return returnDBiBts();
+        return returnDBiBtsWithRAT();
     }
 
     /**
@@ -1277,6 +1283,10 @@ public final class AIMSICDDbAdapter extends SQLiteOpenHelper {
     */
     public Cursor returnDBiBts() {
         return mDb.rawQuery("SELECT * FROM DBi_bts", null);
+    }
+    public Cursor returnDBiBtsWithRAT() {
+        // Basically the same as above, but with RAT from a joined, related table
+        return mDb.rawQuery("SELECT DBi_bts.*, DBi_measure.RAT FROM DBi_bts JOIN DBi_measure ON DBi_measure.bts_id = DBi_bts.CID", null);
     }
 
     // TODO: THESE ARE OUTDATED!! Please see design and update

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/constants/DBTableColumnIds.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/constants/DBTableColumnIds.java
@@ -75,6 +75,7 @@ public class DBTableColumnIds {
     public static final String DBI_BTS_TIME_LAST = "time_last";
     public static final String DBI_BTS_LAT = "gps_lat";
     public static final String DBI_BTS_LON = "gps_lon";
+    public static final String DBI_BTS_JOINED_RAT = "RAT";
 
     //DBi_measure
     public static final String DBI_MEASURE_TABLE_NAME = "DBi_measure";

--- a/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/fragments/MapFragment.java
+++ b/AIMSICD/src/main/java/com/SecUpwN/AIMSICD/fragments/MapFragment.java
@@ -401,8 +401,8 @@ public final class MapFragment extends InjectionFragment implements OnSharedPref
                         final int mcc = c.getInt(c.getColumnIndex(DBTableColumnIds.DBI_BTS_MCC));        // MCC
                         final int mnc = c.getInt(c.getColumnIndex(DBTableColumnIds.DBI_BTS_MNC));        // MNC
                         final int psc = c.getInt(c.getColumnIndex(DBTableColumnIds.DBI_BTS_PSC));        // PSC
-                        // TODO: 2016-02-27 Is there a reason why #DBI_BTS_RAT doesn't exist?
-                        // final String rat = c.getString(c.getColumnIndex(DBTableColumnIds.DBI_BTS_RAT));   // RAT
+                        final String rat = Cell.getRatFromInt(
+                                c.getInt(c.getColumnIndex(DBTableColumnIds.DBI_BTS_JOINED_RAT)));        // RAT
                         final double dLat = c.getDouble(c.getColumnIndex(DBTableColumnIds.DBI_BTS_LAT)); // Lat
                         final double dLng = c.getDouble(c.getColumnIndex(DBTableColumnIds.DBI_BTS_LON)); // Lon
 
@@ -435,7 +435,7 @@ public final class MapFragment extends InjectionFragment implements OnSharedPref
                                             String.valueOf(mcc),
                                             String.valueOf(mnc),
                                             String.valueOf(psc),
-                                            null,
+                                            rat,
                                             "", false)
                             );
                             // The pin of our current position


### PR DESCRIPTION
#### Agreements

- [x] **I have reviewed and accepted the [guidelines for contributing](https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/blob/development/.github/CONTRIBUTING.md) to this project.**
- [x] **I have reviewed and closely followed the [Style Guide](https://github.com/SecUpwN/Android-IMSI-Catcher-Detector/wiki/Style-Guide) for this Android app.**

---

#### Overview

Previously it was showing `Unknown` due to RAT being absent in the DBi_bts schema.

Using JOIN keyword, I get the RAT from the related DBi_measure table. Unless I'm mistaken, they're supposed to be joined by bts_id=CID

This bug only applied to map markers that were not in the OCID database. That is, it was a locally found cell.

---

#### Classification

- [x] Bugfix (non-breaking change which fixes an existing issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

#### Screenshots

You can see the only cell map marker I have is a currently-connected BTS one. That is, it's measured from my cell phone and not OCID. Before this bug fix, `LTE` would say `Unknown`.

![device-2016-02-28-200800](https://cloud.githubusercontent.com/assets/740289/13383492/5206435a-de58-11e5-87a5-8ae12e120e1f.png) ![device-2016-02-28-200817](https://cloud.githubusercontent.com/assets/740289/13383493/52067b5e-de58-11e5-829d-139d757bb362.png)
